### PR TITLE
✨ (Gemfile, development.rb, test.rb, prosopite.rb): add Prosopite gem…

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,10 @@ gem "pghero"
 # Strong migrations catches unsafe migrations in development
 gem "strong_migrations"
 
+# Prosopite catches n+1 queries
+gem "pg_query"
+gem "prosopite"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[mri windows], require: "debug/prelude"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,6 +111,21 @@ GEM
       raabro (~> 1.4)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    google-protobuf (4.29.3)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.29.3-aarch64-linux)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.29.3-arm64-darwin)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.29.3-x86_64-darwin)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.29.3-x86_64-linux)
+      bigdecimal
+      rake (>= 13)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
     io-console (0.8.0)
@@ -184,6 +199,8 @@ GEM
       ast (~> 2.4.1)
       racc
     pg (1.5.9)
+    pg_query (6.0.0)
+      google-protobuf (>= 3.25.3)
     pghero (3.6.1)
       activerecord (>= 6.1)
     pp (0.6.2)
@@ -194,6 +211,7 @@ GEM
       activesupport (>= 7.0.0)
       rack
       railties (>= 7.0.0)
+    prosopite (2.0.0)
     psych (5.2.3)
       date
       stringio
@@ -360,8 +378,10 @@ DEPENDENCIES
   jsbundling-rails
   kamal
   pg (~> 1.1)
+  pg_query
   pghero
   propshaft
+  prosopite
   puma (>= 5.0)
   rails (~> 8.0.1)
   rails_best_practices

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -57,4 +57,12 @@ Rails.application.configure do
 
   # Enable/disable asset pipeline. By default assets are disabled.
   config.assets.debug = true
+
+  # Log N+1 Queries
+  config.after_initialize do
+    Prosopite.rails_logger = true
+  end
+
+  # Force strict loading by default, raise on lazy loading.
+  config.active_record.strict_loading_by_default = true
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -39,4 +39,10 @@ Rails.application.configure do
 
   # Raise error when a before_action's only/except options reference missing actions.
   config.action_controller.raise_on_missing_callback_actions = true
+
+  # Raise on n+1 queries
+  config.after_initialize do
+    Prosopite.rails_logger = true
+    Prosopite.raise = true
+  end
 end

--- a/config/initializers/prosopite.rb
+++ b/config/initializers/prosopite.rb
@@ -1,0 +1,4 @@
+unless Rails.env.production?
+  require "prosopite/middleware/rack"
+  Rails.configuration.middleware.use(Prosopite::Middleware::Rack)
+end


### PR DESCRIPTION
… for N+1 query detection and logging

The Prosopite gem is added to the Gemfile to help identify N+1 query issues during development and testing. Configuration in both development and test environments enables logging and raises errors for N+1 queries, promoting better performance practices. An initializer is created to set up the Prosopite middleware, ensuring it runs in non-production environments. This enhances the application's ability to catch performance issues early in the development cycle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced enhanced query analysis and diagnostic logging to help detect performance inefficiencies.
  - Enabled stricter data loading enforcement and improved error reporting in non-production environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->