### PR TITLE
✨ (rubocop): add rubocop-factory_bot gem and configuration for better…

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,7 @@ plugins:
 
 require:
   - rubocop-rspec_rails
+  - rubocop-factory_bot
 
 AllCops:
   NewCops: enable

--- a/Gemfile
+++ b/Gemfile
@@ -66,6 +66,7 @@ group :development, :test do
 
   # Rubocop for static code analysis
   gem "rubocop", require: false
+  gem "rubocop-factory_bot", require: false
   gem "rubocop-rails", require: false
   gem "rubocop-rspec", require: false
   gem "rubocop-rspec_rails", require: false
@@ -87,6 +88,9 @@ group :development, :test do
 
   # RSpec as testing framework
   gem "rspec-rails"
+
+  # Fixtures replacement with a straightforward definition syntax
+  gem "factory_bot_rails"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,6 +119,11 @@ GEM
     erubis (2.7.0)
     et-orbi (1.2.11)
       tzinfo
+    factory_bot (6.5.1)
+      activesupport (>= 6.1.0)
+    factory_bot_rails (6.4.4)
+      factory_bot (~> 6.5)
+      railties (>= 5.0.0)
     fugit (1.11.1)
       et-orbi (~> 1, >= 1.2.11)
       raabro (~> 1.4)
@@ -324,6 +329,8 @@ GEM
       unicode-display_width (>= 2.4.0, < 4.0)
     rubocop-ast (1.38.0)
       parser (>= 3.3.1.0)
+    rubocop-factory_bot (2.26.1)
+      rubocop (~> 1.61)
     rubocop-rails (2.30.2)
       activesupport (>= 4.2.0)
       lint_roller (~> 1.1)
@@ -429,6 +436,7 @@ DEPENDENCIES
   debug
   devise
   devise-i18n
+  factory_bot_rails
   high_voltage
   jsbundling-rails
   kamal
@@ -443,6 +451,7 @@ DEPENDENCIES
   rails_best_practices
   rspec-rails
   rubocop
+  rubocop-factory_bot
   rubocop-rails
   rubocop-rspec
   rubocop-rspec_rails

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -67,4 +67,6 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  config.include FactoryBot::Syntax::Methods # FactoryBot syntax in specs
 end


### PR DESCRIPTION
… code quality

✨ (Gemfile): include factory_bot_rails gem for easier test data creation ✨ (rails_helper.rb): include FactoryBot syntax methods in RSpec configuration for cleaner tests Adding the `rubocop-factory_bot` gem enhances static code analysis for FactoryBot usage, ensuring adherence to best practices. The inclusion of `factory_bot_rails` in the Gemfile simplifies the creation of test data, making tests more readable and maintainable. Finally, integrating FactoryBot syntax methods into RSpec configuration allows for a more concise and expressive syntax in tests.