### PR TITLE
feat(main_page): add courses list component with caching and tests

### DIFF
--- a/app/components/main_page/courses_list_component.html.haml
+++ b/app/components/main_page/courses_list_component.html.haml
@@ -1,0 +1,23 @@
+%section.container.mx-auto.px-4.mb-16
+  .flex.justify-between.items-center.mb-8
+    %h2.text-2xl.font-bold.text-gray-800= t('.title')
+    %a.text-blue-600.hover:text-blue-800.flex.items-center.transition-colors.duration-200{href: "#"}
+      = t('.view_all')
+      %i.ml-1 →
+  
+  .grid.grid-cols-1.md:grid-cols-2.lg:grid-cols-3.gap-6
+    - courses.each do |course|
+      .bg-white.rounded-lg.shadow-md.overflow-hidden.border.border-gray-200.transition-all.duration-300.hover:shadow-lg.hover:border-blue-300
+        .h-40.bg-gradient-to-r.from-purple-500.to-pink-600
+          .h-full.flex.items-center.justify-center
+            %i.text-white.text-4xl.opacity-50= ["💻", "🔍", "🧩", "📊", "🔐", "🚀"][1]
+        .p-6
+          %h3.text-xl.font-bold.text-gray-800.mb-2= course.title
+          %p.text-gray-600.mb-4.line-clamp-3= course.description.to_plain_text.truncate(100)
+          .flex.justify-between.items-center
+            -# %span.text-sm.text-gray-500
+            -#   %i.mr-1 👥
+            -#   #{rand(10..50)} students
+            %a.text-blue-600.hover:text-blue-800.font-medium.text-sm.flex.items-center{href: "#"}
+              = t('.view_course')
+              %i.ml-1 →

--- a/app/components/main_page/courses_list_component.pl.yml
+++ b/app/components/main_page/courses_list_component.pl.yml
@@ -1,0 +1,4 @@
+pl:
+  title: Nasze kursy
+  view_all: Zobacz wszystkie
+  view_course: Więcej informacji

--- a/app/components/main_page/courses_list_component.rb
+++ b/app/components/main_page/courses_list_component.rb
@@ -1,0 +1,18 @@
+module MainPage
+  # List of random 6 courses on the main page, changed every day
+  class CoursesListComponent < ViewComponent::Base
+    def render?
+      courses.any?
+    end
+
+    private
+
+    def courses
+      Rails.cache.fetch("main_page_programming_courses", expires_in: 1.day) do
+        ProgrammingCourse.with_rich_text_description
+                         .order("RANDOM()")
+                         .limit(6)
+      end
+    end
+  end
+end

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -1,25 +1,2 @@
 = render MainPage::FeaturedCourseComponent.new
-
-%section.container.mx-auto.px-4.mb-16
-  .flex.justify-between.items-center.mb-8
-    %h2.text-2xl.font-bold.text-gray-800 Available Courses
-    %a.text-blue-600.hover:text-blue-800.flex.items-center.transition-colors.duration-200{href: "#"}
-      View All
-      %i.ml-1 →
-  
-  .grid.grid-cols-1.md:grid-cols-2.lg:grid-cols-3.gap-6
-    - 6.times do |i|
-      .bg-white.rounded-lg.shadow-md.overflow-hidden.border.border-gray-200.transition-all.duration-300.hover:shadow-lg.hover:border-blue-300
-        .h-40.bg-gradient-to-r{class: i.even? ? "from-purple-500 to-pink-600" : "from-blue-500 to-indigo-600"}
-          .h-full.flex.items-center.justify-center
-            %i.text-white.text-4xl.opacity-50= ["💻", "🔍", "🧩", "📊", "🔐", "🚀"][i % 6]
-        .p-6
-          %h3.text-xl.font-bold.text-gray-800.mb-2= ["Introduction to Programming", "Web Development Fundamentals", "Data Structures & Algorithms", "Machine Learning Basics", "Cybersecurity Essentials", "Mobile App Development"][i % 6]
-          %p.text-gray-600.mb-4.line-clamp-3= ["Learn the fundamentals of programming with hands-on exercises.", "Master HTML, CSS, and JavaScript to build responsive websites.", "Understand core computer science concepts with practical examples.", "Explore the basics of AI and machine learning algorithms.", "Learn to protect systems and data from cyber threats.", "Build cross-platform mobile applications with modern frameworks."][i % 6]
-          .flex.justify-between.items-center
-            %span.text-sm.text-gray-500
-              %i.mr-1 👥
-              #{rand(10..50)} students
-            %a.text-blue-600.hover:text-blue-800.font-medium.text-sm.flex.items-center{href: "#"}
-              View Course
-              %i.ml-1 →
+= render MainPage::CoursesListComponent.new

--- a/spec/components/main_page/courses_list_component_spec.rb
+++ b/spec/components/main_page/courses_list_component_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe MainPage::CoursesListComponent, type: :component do
+  let(:user) { create(:user) }
+  let(:course) { create(:programming_course, instructor: user) }
+
+  before do
+    allow(Rails.cache).to receive(:fetch).with("main_page_programming_courses", expires_in: 1.day).and_return([course])
+  end
+
+  it "renders the component when courses are available" do
+    render_inline(described_class.new)
+    expect(rendered_content).not_to be_empty
+  end
+
+  it "does not render when no courses are available" do
+    allow(Rails.cache).to receive(:fetch).with("main_page_programming_courses", expires_in: 1.day).and_return([])
+    render_inline(described_class.new)
+    expect(rendered_content).to be_empty
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :programming_course do
-    title { Faker::Lorem.word }
+    title { Faker::Lorem.unique.word }
   end
 
   factory :user do


### PR DESCRIPTION
Introduce a new CoursesListComponent to display a list of random programming courses on the main page. The component caches the courses for one day to improve performance and includes tests to ensure proper rendering. The previous hardcoded courses section has been replaced with this dynamic component. Also, added Polish translations for the component's UI elements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a dynamic, responsive Courses List section on the home page that displays course cards in a grid layout with interactive hover effects.
	- Enhanced the design with modern card layouts featuring gradients, icons, and concise descriptions.
	- Added localization support for Polish, providing language-specific labels for titles and action links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->