### PR TITLE
feat(lessons): add navigation to next lesson and enhance course lesso…

### DIFF
--- a/app/models/programming_course.rb
+++ b/app/models/programming_course.rb
@@ -56,4 +56,8 @@ class ProgrammingCourse < ApplicationRecord
       (approximate_duration_in_minutes / 60.0).round(1)
     end
   end
+
+  def first_lesson
+    programming_course_lessons.order(:created_at).first
+  end
 end

--- a/app/models/programming_course_lesson.rb
+++ b/app/models/programming_course_lesson.rb
@@ -33,4 +33,22 @@ class ProgrammingCourseLesson < ApplicationRecord
 
     content.to_plain_text.scan(/\w/).count / 150.0
   end
+
+  def next_lesson
+    # First try to find next lesson in the same chapter
+    next_in_chapter = programming_course_chapter.programming_course_lessons
+                                                .where("created_at > ?", created_at)
+                                                .order(:created_at)
+                                                .first
+
+    return next_in_chapter if next_in_chapter.present?
+
+    # If no next lesson in current chapter, find first lesson in next chapter
+    next_chapter = programming_course.programming_course_chapters
+                                     .where("created_at > ?", programming_course_chapter.created_at)
+                                     .order(:created_at)
+                                     .first
+
+    next_chapter&.programming_course_lessons&.order(:created_at)&.first
+  end
 end

--- a/app/models/programming_course_lesson.rb
+++ b/app/models/programming_course_lesson.rb
@@ -35,20 +35,26 @@ class ProgrammingCourseLesson < ApplicationRecord
   end
 
   def next_lesson
-    # First try to find next lesson in the same chapter
-    next_in_chapter = programming_course_chapter.programming_course_lessons
-                                                .where("created_at > ?", created_at)
-                                                .order(:created_at)
-                                                .first
+    next_in_chapter || first_lesson_in_next_chapter
+  end
 
-    return next_in_chapter if next_in_chapter.present?
+  private
 
-    # If no next lesson in current chapter, find first lesson in next chapter
+  def next_in_chapter
+    programming_course_chapter.programming_course_lessons
+                              .where("created_at > ?", created_at)
+                              .order(:created_at)
+                              .first
+  end
+
+  def first_lesson_in_next_chapter
     next_chapter = programming_course.programming_course_chapters
                                      .where("created_at > ?", programming_course_chapter.created_at)
                                      .order(:created_at)
                                      .first
 
-    next_chapter&.programming_course_lessons&.order(:created_at)&.first
+    return unless next_chapter
+
+    next_chapter.programming_course_lessons.order(:created_at).first
   end
 end

--- a/app/views/courses/my_courses.html.haml
+++ b/app/views/courses/my_courses.html.haml
@@ -7,7 +7,7 @@
   - if @courses.any?
     .grid.grid-cols-1.gap-6{ class: "sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-3" }
       - @courses.each do |course|
-        = link_to programming_course_path(course), class: "block bg-white rounded-lg shadow-md overflow-hidden transition duration-200 ease-in-out group hover:shadow-xl hover:-translate-y-1" do
+        = link_to programming_course_lesson_path(course.first_lesson), class: "block bg-white rounded-lg shadow-md overflow-hidden transition duration-200 ease-in-out group hover:shadow-xl hover:-translate-y-1" do
           %div
             = image_tag course.cover_image, class: "w-full aspect-video object-cover"
           .p-4

--- a/app/views/programming_course_lessons/show.html.haml
+++ b/app/views/programming_course_lessons/show.html.haml
@@ -19,6 +19,12 @@
           .prose.prose-sm.sm:prose.max-w-none.text-gray-700
             = @lesson.content
 
+          - if @lesson.next_lesson
+            .mt-8.pt-8.border-t.border-gray-200.flex.justify-end
+              = link_to programming_course_lesson_path(@lesson.next_lesson), class: "inline-flex items-center gap-2 text-blue-600 hover:text-blue-800 font-medium" do
+                = t('.next_lesson')
+                = lucide_icon 'arrow-right', class: 'w-4 h-4'
+
       -# Right Column (Navigation)
       .mt-8.lg:mt-0.lg:col-span-1
         %aside.lg:sticky.lg:top-8.space-y-6

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -43,3 +43,4 @@ en:
   programming_course_lessons:
     show:
       course_content: "Course Content"
+      next_lesson: "Next Lesson"

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -113,6 +113,7 @@ pl:
   programming_course_lessons:
     show:
       course_content: "Kontent"
+      next_lesson: "Następna lekcja"
   shared:
     cancel: Anuluj
     save_changes: Zapisz zmiany


### PR DESCRIPTION
…n views

Implement a method to retrieve the next lesson in the ProgrammingCourseLesson model, allowing users to navigate through lessons seamlessly. Update the lesson show view to include a link to the next lesson if available. Additionally, introduce a method in the ProgrammingCourse model to fetch the first lesson, enhancing the course navigation experience. Update English and Polish locale files to support the new "Next Lesson" feature.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Users are now directed straight to the first lesson when selecting a course from "My Courses".
  - A "Next Lesson" navigation link is displayed at the end of each lesson, allowing users to move sequentially through course lessons.
- **Localization**
  - Added translations for the "Next Lesson" link in both English and Polish.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->