### PR TITLE
feat: implement publish functionality for programming courses

### DIFF
--- a/app/components/instructor/programming_courses_list_component.html.haml
+++ b/app/components/instructor/programming_courses_list_component.html.haml
@@ -54,8 +54,10 @@
             = image_tag "default_cover_image.png", class: "w-full aspect-[16/9] object-cover"
           -# Status Badge (e.g., Published, Draft)
           .absolute.top-3.left-3
-            -# TODO: Logic for different statuses (e.g., if course.published?)
-            %span.px-2.5.py-1.rounded-full.text-xs.font-medium.text-success.ring-1.ring-inset{class: "bg-success/10 ring-success/30"}= t("instructor.programming_courses_list_component.status_published")
+            - if course.published?
+              %span.px-2.5.py-1.rounded-full.text-xs.font-medium.text-success.ring-1.ring-inset{class: "bg-success/10 ring-success/30"}= t("instructor.programming_courses_list_component.status_published")
+            - else
+              %span.px-2.5.py-1.rounded-full.text-xs.font-medium.text-warning.ring-1.ring-inset{class: "bg-warning/10 ring-warning/30"}= t("instructor.programming_courses_list_component.status_draft")
 
           -# Actions Dropdown
           .absolute.top-3.right-3{"data-controller": "dropdown"}
@@ -65,10 +67,10 @@
               = link_to instructor_programming_course_path(course), class: "group flex items-center w-full px-3 py-2 text-sm text-text-secondary hover:bg-bg-hover hover:text-accent" do
                 = lucide_icon("settings-2", class: "w-4 h-4 mr-2.5 text-text-tertiary group-hover:text-accent")
                 = t("instructor.programming_courses_list_component.manage_course")
-              -# TODO: Add Publish/Unpublish logic and button
-              %button.group.flex.items-center.w-full.px-3.py-2.text-sm.text-text-secondary.hover:bg-bg-hover.hover:text-success{disabled: true}
-                = lucide_icon("cloud-upload", class: "w-4 h-4 mr-2.5 text-text-tertiary group-hover:text-success")
-                = t("instructor.programming_courses_list_component.publish_course")
+              - unless course.published?
+                = button_to publish_instructor_programming_course_path(course), method: :post, class: "group flex items-center w-full px-3 py-2 text-sm text-text-secondary hover:bg-bg-hover hover:text-success" do
+                  = lucide_icon("cloud-upload", class: "w-4 h-4 mr-2.5 text-text-tertiary group-hover:text-success")
+                  = t("instructor.programming_courses_list_component.publish_course")
 
         .p-5.flex.flex-col.flex-grow
           %h3.text-lg.font-semibold.text-text-primary.line-clamp-2.mb-1.group-hover:text-accent.transition-colors= link_to course.title, instructor_programming_course_path(course)

--- a/app/controllers/instructor/programming_courses_controller.rb
+++ b/app/controllers/instructor/programming_courses_controller.rb
@@ -50,6 +50,17 @@ module Instructor
       end
     end
 
+    def publish
+      @course = policy_scope(ProgrammingCourse, policy_scope_class: POLICY_SCOPE_CLASS).find(params[:id])
+      authorize @course, policy_class: POLICY_CLASS
+
+      if @course.update(published: true)
+        redirect_to instructor_programming_courses_path, notice: t(".success")
+      else
+        redirect_to instructor_programming_course_path(@course), alert: t(".error")
+      end
+    end
+
     private
 
     def course_params

--- a/app/models/programming_course.rb
+++ b/app/models/programming_course.rb
@@ -4,6 +4,7 @@
 # Table name: programming_courses
 #
 #  id            :bigint           not null, primary key
+#  published     :boolean          default(FALSE)
 #  slug          :string
 #  title         :string           not null
 #  created_at    :datetime         not null
@@ -22,6 +23,8 @@
 #
 class ProgrammingCourse < ApplicationRecord
   extend FriendlyId
+
+  default_scope { where(published: true) }
 
   belongs_to :instructor, class_name: "User"
   has_rich_text :description

--- a/app/models/programming_course.rb
+++ b/app/models/programming_course.rb
@@ -4,7 +4,7 @@
 # Table name: programming_courses
 #
 #  id            :bigint           not null, primary key
-#  published     :boolean          default(FALSE)
+#  published     :boolean          default(FALSE), not null
 #  slug          :string
 #  title         :string           not null
 #  created_at    :datetime         not null

--- a/app/policies/instructor/programming_course_policy.rb
+++ b/app/policies/instructor/programming_course_policy.rb
@@ -6,7 +6,7 @@ module Instructor
     end
 
     def show?
-      user.instructor?
+      record.instructor == user
     end
 
     def create?
@@ -14,7 +14,7 @@ module Instructor
     end
 
     def update?
-      user.instructor?
+      record.instructor == user
     end
 
     def publish?

--- a/app/policies/instructor/programming_course_policy.rb
+++ b/app/policies/instructor/programming_course_policy.rb
@@ -17,10 +17,14 @@ module Instructor
       user.instructor?
     end
 
+    def publish?
+      record.instructor == user
+    end
+
     # Only allow instructor to manage courses created by themself
     class Scope < ApplicationPolicy::Scope
       def resolve
-        scope.where(instructor: user).friendly
+        scope.unscoped.where(instructor: user).friendly.order(created_at: :desc)
       end
     end
   end

--- a/app/views/courses/my.html.haml
+++ b/app/views/courses/my.html.haml
@@ -45,6 +45,6 @@
       = lucide_icon("book-dashed", class: "w-16 h-16 text-text-tertiary mx-auto mb-5")
       %h3.text-xl.font-semibold.text-text-primary.mb-2= t("courses.my.no_courses_enrolled_title")
       %p.text-text-secondary.mb-6= t("courses.my.no_courses_enrolled_description")
-      = link_to t("courses.my.browse_courses"), courses_path, class: "inline-flex items-center justify-center px-5 py-2.5 text-sm font-medium text-accent-content bg-accent hover:bg-accent-hover rounded-lg transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-accent focus:ring-offset-bg-secondary" do
+      = link_to courses_path, class: "inline-flex items-center justify-center px-5 py-2.5 text-sm font-medium text-accent-content bg-accent hover:bg-accent-hover rounded-lg transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-accent focus:ring-offset-bg-secondary" do
         = lucide_icon("search", class: "w-4 h-4 mr-2")
         = t("courses.my.browse_courses_button")

--- a/combine_source.rb
+++ b/combine_source.rb
@@ -42,12 +42,12 @@ def process_file(file_path, output_file)
   output_file.puts "#{'=' * 80}\n"
   output_file.puts content
 rescue StandardError => e
-  puts "Error processing #{file_path}: #{e.message}"
+  Rails.logger.debug { "Error processing #{file_path}: #{e.message}" }
 end
 
 def main
   output_path = "source_code.txt"
-  puts "Combining source code files into #{output_path}..."
+  Rails.logger.debug { "Combining source code files into #{output_path}..." }
 
   File.open(output_path, "w") do |output_file|
     Dir.glob("**/*").each do |path|
@@ -55,12 +55,12 @@ def main
       next if EXCLUDED_DIRS.any? { |dir| path.include?("/#{dir}/") || path.start_with?("#{dir}/") }
       next unless SOURCE_EXTENSIONS.include?(File.extname(path).downcase)
 
-      puts "Processing: #{path}"
+      Rails.logger.debug { "Processing: #{path}" }
       process_file(path, output_file)
     end
   end
 
-  puts "Done! Source code has been combined into #{output_path}"
+  Rails.logger.debug { "Done! Source code has been combined into #{output_path}" }
 end
 
 main

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -10,6 +10,9 @@ pl:
       must_be_instructor: Musisz być instruktorem, aby wykonać tę akcję.
   instructor:
     programming_courses:
+      publish:
+        success: Kurs został opublikowany.
+        error: Nie udało się opublikować kursu.
       new:
         title: "Rozpocznij Tworzenie Nowego Kursu" # Main page title
         subtitle_html: "Nadaj swojemu kursowi chwytliwy tytuł. Możesz go później zmienić." # Subtitle

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,9 @@ Rails.application.routes.draw do
   namespace :instructor do
     resources :courses, only: %i[new]
     resources :programming_courses, except: %i[destroy] do
+      member do
+        post :publish
+      end
       resources :lessons, controller: "programming_course_lessons", only: %i[new create edit update]
     end
   end
@@ -29,6 +32,7 @@ Rails.application.routes.draw do
   end
 
   resources :programming_courses, only: %i[show]
+
   resources :programming_course_enrollments, only: %i[create]
 
   resources :programming_course_lessons, only: %i[show]

--- a/db/migrate/20250521133200_add_published_to_programming_course.rb
+++ b/db/migrate/20250521133200_add_published_to_programming_course.rb
@@ -1,5 +1,5 @@
 class AddPublishedToProgrammingCourse < ActiveRecord::Migration[8.0]
   def change
-    add_column :programming_courses, :published, :boolean, default: false
+    add_column :programming_courses, :published, :boolean, default: false, null: false
   end
 end

--- a/db/migrate/20250521133200_add_published_to_programming_course.rb
+++ b/db/migrate/20250521133200_add_published_to_programming_course.rb
@@ -1,0 +1,5 @@
+class AddPublishedToProgrammingCourse < ActiveRecord::Migration[8.0]
+  def change
+    add_column :programming_courses, :published, :boolean, default: false
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -331,7 +331,8 @@ CREATE TABLE public.programming_courses (
     instructor_id bigint NOT NULL,
     created_at timestamp(6) with time zone NOT NULL,
     updated_at timestamp(6) with time zone NOT NULL,
-    slug character varying
+    slug character varying,
+    published boolean DEFAULT false
 );
 
 
@@ -988,6 +989,7 @@ ALTER TABLE ONLY public.active_storage_attachments
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250521133200'),
 ('20250518065644'),
 ('20250516170436'),
 ('20250516162302'),

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -332,7 +332,7 @@ CREATE TABLE public.programming_courses (
     created_at timestamp(6) with time zone NOT NULL,
     updated_at timestamp(6) with time zone NOT NULL,
     slug character varying,
-    published boolean DEFAULT false
+    published boolean DEFAULT false NOT NULL
 );
 
 

--- a/spec/models/programming_course_spec.rb
+++ b/spec/models/programming_course_spec.rb
@@ -3,6 +3,7 @@
 # Table name: programming_courses
 #
 #  id            :bigint           not null, primary key
+#  published     :boolean          default(FALSE)
 #  slug          :string
 #  title         :string           not null
 #  created_at    :datetime         not null

--- a/spec/models/programming_course_spec.rb
+++ b/spec/models/programming_course_spec.rb
@@ -3,7 +3,7 @@
 # Table name: programming_courses
 #
 #  id            :bigint           not null, primary key
-#  published     :boolean          default(FALSE)
+#  published     :boolean          default(FALSE), not null
 #  slug          :string
 #  title         :string           not null
 #  created_at    :datetime         not null

--- a/spec/policies/instructor/programming_course_policy_spec.rb
+++ b/spec/policies/instructor/programming_course_policy_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Instructor::ProgrammingCoursePolicy, type: :policy do
     end
   end
 
-  permissions :show?, :update? do
+  permissions :show?, :publish?, :update? do
     it "denies access if user is not an instructor" do
       expect(subject).not_to permit(regular_user, course)
     end

--- a/spec/requests/instructor/programming_courses_spec.rb
+++ b/spec/requests/instructor/programming_courses_spec.rb
@@ -288,4 +288,47 @@ RSpec.describe "Instructor::ProgrammingCourses" do
       end
     end
   end
+
+  describe "POST /instructor/programming_courses/:id/publish" do
+    context "when user is not authenticated" do
+      it "redirects to sign in page" do
+        post publish_instructor_programming_course_path(programming_course)
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context "when user is authenticated as instructor" do
+      before do
+        sign_in user
+      end
+
+      it "publishes the course" do
+        post publish_instructor_programming_course_path(programming_course)
+        expect(response).to redirect_to(instructor_programming_courses_path)
+      end
+
+      it "sets the course as published" do
+        post publish_instructor_programming_course_path(programming_course)
+        expect(programming_course.reload.published).to be(true)
+      end
+
+      it "does not publish another instructor's course" do
+        post publish_instructor_programming_course_path(another_course)
+        expect(response).not_to redirect_to(instructor_programming_courses_path)
+      end
+    end
+
+    context "when user is not an instructor" do
+      let(:regular_user) { create(:user) }
+
+      before do
+        sign_in regular_user
+      end
+
+      it "forbids unauthorized access" do
+        post publish_instructor_programming_course_path(programming_course)
+        expect(response).to be_forbidden
+      end
+    end
+  end
 end


### PR DESCRIPTION
Added a publish feature to the programming courses, allowing instructors to publish their courses. Updated the programming courses list component to display the course status (published or draft) and included a button for publishing courses. Enhanced the programming course policy to authorize publishing actions and added a migration to include a published boolean field in the database.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability for instructors to publish programming courses directly from the course list UI.
  - Status badges now indicate whether a course is "Published" or "Draft".
  - Instructors see a "Publish" button for unpublished courses.

- **Bug Fixes**
  - Improved authorization checks to ensure only the course's instructor can publish or manage the course.

- **Localization**
  - Added Polish translations for course publishing success and error messages.

- **Tests**
  - Expanded test coverage for publishing permissions and actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->